### PR TITLE
Fix broken asset paths in Runa Libro

### DIFF
--- a/public/runa-libro/css/style.css
+++ b/public/runa-libro/css/style.css
@@ -73,7 +73,7 @@ html.dark .font-button.active { background-color: rgba(255,255,255,0.3); }
 .flipbook .hard { background-color: #101010; box-shadow: inset 0 0 5px #000; }
 .cover-page { 
     background-color: #101010 !important;
-    background-image: url(/assets/imagenes/portada-libro.jpg);
+    background-image: url(../../assets/imagenes/portada-libro.jpg);
     background-size: contain !important;
     background-repeat: no-repeat !important;
     background-position: center !important;
@@ -229,7 +229,7 @@ input[type="range"].styled-slider::-moz-range-track {
     box-shadow: 0 10px 30px rgba(0,0,0,0.5), inset 0 2px 3px rgba(255,255,255,0.2);
     z-index: 1001;
     display: none;
-    background-image: url(/assets/imagenes/portada-libro.jpg);
+    background-image: url(../../assets/imagenes/portada-libro.jpg);
     background-size: cover;
     background-position: center;
     padding: 10px;

--- a/public/runa-libro/index.html
+++ b/public/runa-libro/index.html
@@ -33,7 +33,7 @@
 <div id="video-background-wrapper">
     <video id="video-background" autoplay loop muted playsinline>
         <!-- RUTA CORREGIDA -->
-        <source id="video-source" src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/videos/runa-fondo-video.mp4" type="video/mp4">
+        <source id="video-source" src="../assets/videos/runa-fondo-video.mp4" type="video/mp4">
     </video>
 </div>
 
@@ -58,7 +58,7 @@
              <a href="index.html" class="h-16 w-16 flex items-center justify-center rounded-full overflow-hidden bg-white shadow-md">
                  <video autoplay loop muted playsinline class="w-full h-full object-contain">
                      <!-- RUTA CORREGIDA -->
-                     <source src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/videos/runa-logo-animado.mp4" type="video/mp4">
+                     <source src="../assets/videos/runa-logo-animado.mp4" type="video/mp4">
                  </video>
              </a>
         </div>
@@ -70,7 +70,7 @@
             <button id="mixer-toggle-button" class="w-9 h-9 rounded-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--runa-primary)]" aria-label="Abrir mezclador de ambiente">
                 <video autoplay loop muted playsinline class="w-full h-full object-cover">
                     <!-- RUTA CORREGIDA -->
-                    <source src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/videos/runa-equalizer-video.mp4" type="video/mp4">
+                    <source src="../assets/videos/runa-equalizer-video.mp4" type="video/mp4">
                 </video>
             </button>
             <div id="cart-icon-wrapper" class="relative">
@@ -235,7 +235,7 @@
                 <!-- Páginas de Portal -->
                 <div class="page portal-page" data-drawing-enabled="false">
                     <div class="content-wrapper">
-                        <video class="portal-video" autoplay loop muted playsinline src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/videos/runa-fondo-video.mp4"></video>
+                        <video class="portal-video" autoplay loop muted playsinline src="../assets/videos/runa-fondo-video.mp4"></video>
                         <div class="portal-overlay translucent-panel">
                             <div class="portal-content">
                                 <h2>Tienda RUNA</h2>
@@ -249,7 +249,7 @@
 
                 <div class="page portal-page" data-drawing-enabled="false">
                     <div class="content-wrapper">
-                        <video class="portal-video" autoplay loop muted playsinline src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/videos/runa_video_fondo_1.mp4"></video>
+                        <video class="portal-video" autoplay loop muted playsinline src="../assets/videos/runa_video_fondo_1.mp4"></video>
                         <div class="portal-overlay translucent-panel">
                              <div class="portal-content">
                                  <h2>Juego RUNA</h2>
@@ -264,7 +264,7 @@
 
                 <div class="page portal-page" data-drawing-enabled="false">
                    <div class="content-wrapper">
-                        <video class="portal-video" autoplay loop muted playsinline src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/videos/runa-intro.mp4"></video>
+                        <video class="portal-video" autoplay loop muted playsinline src="../assets/videos/runa-intro.mp4"></video>
                         <div class="portal-overlay translucent-panel">
                              <div class="portal-content">
                                  <h2>Jusn38 Tech</h2>
@@ -356,12 +356,12 @@
 </div>
 
 <!-- Elementos de Audio -->
-<audio id="river-audio" loop><source src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/mp3/rio.mp3" type="audio/mpeg"></audio>
-<audio id="birds-audio" loop><source src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/mp3/pajaros.mp3" type="audio/mpeg"></audio>
-<audio id="rain-audio" loop><source src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/mp3/lluvia.mp3" type="audio/mpeg"></audio>
-<audio id="fire-audio" loop><source src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/mp3/fuego.mp3" type="audio/mpeg"></audio>
-<audio id="wind-audio" loop><source src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/mp3/viento.mp3" type="audio/mpeg"></audio>
-<audio id="storm-audio" loop><source src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/mp3/tormenta.mp3" type="audio/mpeg"></audio>
+<audio id="river-audio" loop><source src="../assets/mp3/rio.mp3" type="audio/mpeg"></audio>
+<audio id="birds-audio" loop><source src="../assets/mp3/pajaros.mp3" type="audio/mpeg"></audio>
+<audio id="rain-audio" loop><source src="../assets/mp3/lluvia.mp3" type="audio/mpeg"></audio>
+<audio id="fire-audio" loop><source src="../assets/mp3/fuego.mp3" type="audio/mpeg"></audio>
+<audio id="wind-audio" loop><source src="../assets/mp3/viento.mp3" type="audio/mpeg"></audio>
+<audio id="storm-audio" loop><source src="../assets/mp3/tormenta.mp3" type="audio/mpeg"></audio>
 
 <!-- Tu Script Personalizado -->
 <script type="module" src="js/script.js"></script>

--- a/public/runa-libro/js/script.js
+++ b/public/runa-libro/js/script.js
@@ -35,7 +35,7 @@ $(document).ready(function () {
 
         if (user && !user.isAnonymous) {
             // RUTA CORREGIDA para la imagen de fallback
-            const fallbackImage = 'https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/imagenes/logo-google.png';
+            const fallbackImage = '../../assets/imagenes/logo-google.png';
             const photoURL = user.photoURL || fallbackImage;
 
             const userButton = $(`
@@ -53,7 +53,7 @@ $(document).ready(function () {
             // RUTA CORREGIDA para la imagen de login
             const loginButton = $(`
                 <button id="open-auth-modal-button" class="p-1 rounded-full text-white" aria-label="Abrir modal de inicio de sesión">
-                    <img src="https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/imagenes/logo-google.png" alt="Iniciar sesión" class="w-7 h-7">
+                    <img src="../../assets/imagenes/logo-google.png" alt="Iniciar sesión" class="w-7 h-7">
                 </button>
             `);
             loginButton.on('click', () => {
@@ -98,7 +98,7 @@ $(document).ready(function () {
     let isDrawing = false;
     let lastX = 0, lastY = 0;
     // RUTA CORREGIDA para el sonido
-    const pageFlipSound = new Audio('https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/mp3/page-flip.mp3');
+    const pageFlipSound = new Audio('../../assets/mp3/page-flip.mp3');
     const visualTool = $('#visual-tool');
     
     // --- Constantes y Datos ---
@@ -114,17 +114,17 @@ $(document).ready(function () {
     ];
     const videoSkins = [
         // RUTA CORREGIDA para el video
-        { name: "Naturaleza y Café", url: "https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/videos/runa-fondo-video.mp4" }
+        { name: "Naturaleza y Café", url: "../../assets/videos/runa-fondo-video.mp4" }
     ];
     let currentVideoIndex = 0;
     const ambienceSounds = [
         // RUTAS CORREGIDAS para los GIFs
-        { id: 'river-audio', name: 'Río', gifSrc: 'https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/gif/river.gif' },
-        { id: 'birds-audio', name: 'Pájaros', gifSrc: 'https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/gif/birds.gif' },
-        { id: 'rain-audio', name: 'Lluvia', gifSrc: 'https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/gif/rain.gif' },
-        { id: 'fire-audio', name: 'Fuego', gifSrc: 'https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/gif/fire.gif' },
-        { id: 'wind-audio', name: 'Viento', gifSrc: 'https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/gif/wind.gif' },
-        { id: 'storm-audio', name: 'Tormenta', gifSrc: 'https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/assets/gif/storm.gif' },
+        { id: 'river-audio', name: 'Río', gifSrc: '../../assets/gif/river.gif' },
+        { id: 'birds-audio', name: 'Pájaros', gifSrc: '../../assets/gif/birds.gif' },
+        { id: 'rain-audio', name: 'Lluvia', gifSrc: '../../assets/gif/rain.gif' },
+        { id: 'fire-audio', name: 'Fuego', gifSrc: '../../assets/gif/fire.gif' },
+        { id: 'wind-audio', name: 'Viento', gifSrc: '../../assets/gif/wind.gif' },
+        { id: 'storm-audio', name: 'Tormenta', gifSrc: '../../assets/gif/storm.gif' },
     ];
 
     // --- Definiciones de Funciones (sin cambios en la lógica interna) ---


### PR DESCRIPTION
You reported that several assets in the Runa Libro feature were not loading: the background video was black, the page-turn sound was not playing, and the equalizer GIFs were not displaying.

This was caused by the application trying to load these assets from absolute URLs pointing to a raw GitHub repository.

I've fixed the issue by replacing all hardcoded `raw.githubusercontent.com` URLs in the HTML, CSS, and JavaScript files with appropriate relative paths that point to the local assets stored within the `public/assets` directory. This makes the Runa Libro component self-contained and ensures all assets load correctly.