### PR TITLE
Refactor: Move inline styles from HTML to CSS in Runa Libro

### DIFF
--- a/public/runa-libro/css/style.css
+++ b/public/runa-libro/css/style.css
@@ -341,3 +341,17 @@ input[type="range"].styled-slider::-moz-range-track {
 #visual-tool.eraser {
     transform: translate(-20px, -20px);
 }
+
+/* --- Refactored Inline Styles --- */
+.runa-coffee-title {
+    font-family: 'Poppins', sans-serif;
+    font-weight: 700;
+}
+
+.calc-btn.calc-btn-enter {
+    grid-row: span 2;
+}
+
+.calc-btn.calc-btn-zero {
+    grid-column: span 2;
+}

--- a/public/runa-libro/index.html
+++ b/public/runa-libro/index.html
@@ -158,7 +158,7 @@
                 <!-- Página 1: Título -->
                 <div class="page" data-drawing-enabled="false">
                     <div class="content-wrapper flex flex-col justify-center items-center">
-                        <h2 class="text-6xl text-center uppercase" style="font-family: 'Poppins', sans-serif; font-weight: 700;">RUNA COFFEE</h2>
+                        <h2 class="text-6xl text-center uppercase runa-coffee-title">RUNA COFFEE</h2>
                     </div>
                     <div class="page-number">1</div>
                 </div>
@@ -347,8 +347,8 @@
             <button class="calc-btn num" data-key="2">2</button>
             <button class="calc-btn num" data-key="3">3</button>
             <button class="calc-btn op" data-key="+">+</button>
-            <button class="calc-btn enter" id="calc-equals" style="grid-row: span 2;">ENTER</button>
-            <button class="calc-btn num" data-key="0" style="grid-column: span 2;">0</button>
+            <button class="calc-btn enter calc-btn-enter" id="calc-equals">ENTER</button>
+            <button class="calc-btn num calc-btn-zero" data-key="0">0</button>
             <button class="calc-btn num" data-key=".">.</button>
             <button class="calc-btn op" data-key="*(-1)">(-)</button>
         </div>


### PR DESCRIPTION
This commit refactors the `runa-libro/index.html` file to improve code quality and maintainability.

- Identified all inline `style` attributes on elements within the HTML.
- Created new, specific CSS classes in `runa-libro/css/style.css` to encapsulate these styles.
- Replaced the inline styles in the HTML with the corresponding new CSS classes.

This change improves the separation of concerns by moving presentational logic from the HTML structure to the external stylesheet, making the code cleaner and easier to manage without affecting the visual appearance.