### PR TITLE
Fix: Correct game link in libro.html

### DIFF
--- a/public/libro.html
+++ b/public/libro.html
@@ -571,7 +571,7 @@
                             <div class="portal-content">
                                 <h2>Juego RUNA</h2>
                                 <p>Pon a prueba tus sentidos y sumérgete en el mundo de RUNA con nuestro juego interactivo. ¿Estás listo para el desafío?</p>
-                                <a href="RunaDefenders/juego.html" class="portal-button">Jugar Ahora</a>
+                                <a href="RunaDefenders/index.html" class="portal-button">Jugar Ahora</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Updated the href for the 'Jugar Ahora' button to point to the correct `index.html` file within the `RunaDefenders` directory, as the previous link to `juego.html` was broken.u7