### PR TITLE
feat: Add ambient sound to Runa Defenders

### DIFF
--- a/public/RunaDefenders/index.html
+++ b/public/RunaDefenders/index.html
@@ -133,6 +133,6 @@
     </div>
 
     <!-- RUTA CORREGIDA: Ahora apunta a la carpeta js -->
-    <script type="module" src="js/script.js"></script>
+    <script type="module" src="js/main.js"></script>
 </body>
 </html>

--- a/public/RunaDefenders/js/main.js
+++ b/public/RunaDefenders/js/main.js
@@ -73,7 +73,7 @@ async function startGame() {
     await startAudioContext(); 
     
     // --- MODIFICADO: Reproduce la música solo si se cargó y es el nivel 1 ---
-    if (isMusicLoaded && currentLevelIndex === 0) {
+    if (isMusicLoaded) {
         playMusic();
     }
 
@@ -115,7 +115,7 @@ function togglePause() {
         showOverlay('pause');
     } else if (currentState === 'paused') {
         // --- MODIFICADO: Reanuda la música solo si se cargó y es el nivel 1 ---
-        if (isMusicLoaded && currentLevelIndex === 0) {
+        if (isMusicLoaded) {
             playMusic();
         }
         setGameState('playing');
@@ -201,7 +201,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     // Intenta cargar la música de fondo
     try {
-        const musicUrl = 'https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/RunaDefenders/assets/audio/music/nivel1_musica.mp3';
+        const musicUrl = 'assets/audio/music/nivel1_musica.mp3';
         await loadMusic(musicUrl);
         isMusicLoaded = true;
     } catch (error) {


### PR DESCRIPTION
This commit adds ambient sound to the Runa Defenders game.

- The music now plays on all levels, not just the first one.
- The music is loaded from the local assets folder instead of a remote URL.
- A bug was fixed in `index.html` where it was loading `script.js` instead of `main.js`.