### PR TITLE
Fix: Correct audio file path in Runa Defenders

### DIFF
--- a/public/RunaDefenders/js/script.js
+++ b/public/RunaDefenders/js/script.js
@@ -421,7 +421,7 @@ const sounds = {
     powerDown: new Tone.PolySynth(Tone.AMSynth, { harmonicity: 1.5, detune: 0, oscillator: { type: "square" }, envelope: { attack: 0.01, decay: 0.5, sustain: 0, release: 0.5 }, modulation: { type: "sawtooth" }, modulationEnvelope: { attack: 0.1, decay: 0.2, sustain: 0, release: 0.5 } }).toDestination(),
     // --- NEW: Background music for level 1 ---
     backgroundMusic: new Tone.Player({
-        url: "https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/main/public/RunaDefenders/assets/audio/music/nivel1_musica.mp3",
+            url: "../assets/audio/music/nivel1_musica.mp3",
         loop: true,
         volume: -12 // Lower volume for background music
     }).toDestination()


### PR DESCRIPTION
Updated the hardcoded URL for the background music to a relative path in `public/RunaDefenders/js/script.js`. This fixes an issue where the background music was not playing after the refactor to separate assets.