### PR TITLE
Adjust cover image scaling to cover the entire page

### DIFF
--- a/public/runa-libro/index.html
+++ b/public/runa-libro/index.html
@@ -94,7 +94,7 @@
         .cover-page { 
             background-color: #101010 !important;
             background-image: url(https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/fda92b2028bf402986396801d14ae0bc4bb58359/public/assets/imagenes/portada-libro.jpg);
-            background-size: contain !important;
+            background-size: cover !important;
             background-repeat: no-repeat !important;
             background-position: center !important;
         }
@@ -102,7 +102,7 @@
         .back-cover-page {
             background-color: #101010 !important;
             background-image: url(assets/imagenes/portada-trasera-libro.jpg);
-            background-size: contain !important;
+            background-size: cover !important;
             background-repeat: no-repeat !important;
             background-position: center !important;
         }


### PR DESCRIPTION
Changed the background-size property for the front and back cover images from 'contain' to 'cover'. This ensures the images fill the entire page area, removing the letterbox effect.