### PR TITLE
Revert front cover image scaling to contain

### DIFF
--- a/public/runa-libro/index.html
+++ b/public/runa-libro/index.html
@@ -94,7 +94,7 @@
         .cover-page { 
             background-color: #101010 !important;
             background-image: url(https://raw.githubusercontent.com/Yanzsmartwood2025/Runacoffee/fda92b2028bf402986396801d14ae0bc4bb58359/public/assets/imagenes/portada-libro.jpg);
-            background-size: cover !important;
+            background-size: contain !important;
             background-repeat: no-repeat !important;
             background-position: center !important;
         }


### PR DESCRIPTION
Reverted the background-size property for the front cover image from 'cover' back to 'contain' as requested. The back cover image scaling remains set to 'cover'.