### PR TITLE
feat: Reduce projectile speed

### DIFF
--- a/public/RunaDefenders/index.html
+++ b/public/RunaDefenders/index.html
@@ -865,7 +865,7 @@
     const config = {
         lanes: 4,
         playerSpeed: 5,
-        projectileSpeed: 8,
+        projectileSpeed: 4,
         shootCooldown: 40,
         fastShootCooldown: 15,
         specialPowerMax: 100,


### PR DESCRIPTION
This commit reduces the projectile speed from 8 to 4. This change was requested by the user to make the coffee bean's spinning animation more visible during gameplay.