### PR TITLE
Fix: Carousel arrows not working on iOS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -630,15 +630,23 @@
                 sliderTrack.style.transform = `translateX(-${index * 100}%)`;
             };
 
-            nextButton.addEventListener('click', () => {
+            const handleNext = (e) => {
+                e.preventDefault();
                 currentIndex = (currentIndex + 1) % totalSlides;
                 goToSlide(currentIndex);
-            });
+            };
 
-            prevButton.addEventListener('click', () => {
+            const handlePrev = (e) => {
+                e.preventDefault();
                 currentIndex = (currentIndex - 1 + totalSlides) % totalSlides;
                 goToSlide(currentIndex);
-            });
+            };
+
+            nextButton.addEventListener('click', handleNext);
+            nextButton.addEventListener('touchstart', handleNext);
+
+            prevButton.addEventListener('click', handlePrev);
+            prevButton.addEventListener('touchstart', handlePrev);
         }
 
         // --- INICIALIZACIÓN DE LA PÁGINA ---


### PR DESCRIPTION
The carousel navigation buttons were not responding to touch events on iOS devices. This was because they were only listening for 'click' events.

This change adds 'touchstart' event listeners to the previous and next buttons in the product catalog carousel. This ensures that the buttons are responsive on touch-based devices, specifically iOS, where 'click' events can be unreliable for custom-styled interactive elements.

`event.preventDefault()` has also been added to the event handlers to prevent the default browser behavior (like scrolling) when tapping the buttons.