### PR TITLE
feat: replace hand icon with animated glove

### DIFF
--- a/public/css/main-style.css
+++ b/public/css/main-style.css
@@ -79,22 +79,34 @@ html:not(.dark) #ar-viewer::part(ar-button):hover { background-color: var(--runa
     cursor: grabbing;
 }
 
-@keyframes swipe-hand {
+.swipe-glove {
+    width: 50px;
+    height: auto;
+}
+
+@keyframes swipe-glove-animation {
     0% {
-        transform: translateX(0);
-        opacity: 0.8;
+        transform: translateX(0) scaleX(-1);
+        opacity: 0;
+    }
+    25% {
+        transform: translateX(-25px) scaleX(-1);
+        opacity: 1;
     }
     50% {
-        transform: translateX(-25px);
+        transform: translateX(0) scaleX(-1);
+        opacity: 0;
+    }
+    75% {
+        transform: translateX(25px) scaleX(1);
         opacity: 1;
     }
     100% {
-        transform: translateX(-50px);
+        transform: translateX(0) scaleX(1);
         opacity: 0;
     }
 }
 
-#swipe-indicator.animate {
-    display: block;
-    animation: swipe-hand 2s ease-in-out infinite;
+#swipe-indicator.animate img {
+    animation: swipe-glove-animation 3s ease-in-out infinite;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -146,14 +146,7 @@
                     <div class="relative max-w-lg mx-auto">
                         <!-- Contenedor del Carrusel -->
                         <div id="swipe-indicator" class="absolute top-4 right-4 z-20 pointer-events-none hidden">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-white" style="filter: drop-shadow(0px 2px 4px rgba(0,0,0,0.7));" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M15 5H9a4 4 0 0 0-4 4v6a4 4 0 0 0 4 4h6a4 4 0 0 0 4-4V9a4 4 0 0 0-4-4z" />
-                                <path d="M9 5.1L15 5" />
-                                <path d="M9 19L15 18.9" />
-                                <path d="M5.1 9L5 15" />
-                                <path d="M19 9L18.9 15" />
-                                <path d="M12 12m-2 0a2 2 0 1 0 4 0a2 2 0 1 0-4 0" />
-                            </svg>
+                            <img src="assets/imagenes/Guante.png" alt="Deslizar" class="swipe-glove" style="filter: drop-shadow(0px 2px 4px rgba(0,0,0,0.7));">
                         </div>
                         <div class="overflow-hidden rounded-2xl">
                             <div id="slider-track" class="flex transition-transform duration-500 ease-in-out">


### PR DESCRIPTION
- Replaced the SVG hand icon with a PNG image of a glove.
- Added a new CSS class to style the glove image.
- Created a new CSS animation to make the glove move left and right, indicating that the carousel is slidable.
- Applied the new animation to the glove image.