### PR TITLE
feat: adjust swipe hint position and animation

### DIFF
--- a/public/css/main-style.css
+++ b/public/css/main-style.css
@@ -101,8 +101,8 @@ html:not(.dark) #ar-viewer::part(ar-button):hover { background-color: var(--runa
 
 #carousel-swipe-hint {
     position: absolute;
-    bottom: 20px;
-    right: 20px;
+    bottom: 20px !important;
+    right: 20px !important;
     z-index: 25;
     pointer-events: none;
     opacity: 0;


### PR DESCRIPTION
- Moved the hand icon hint to the bottom-right corner of the carousel.
- Updated the CSS animation to create a back-and-forth motion, better indicating the bi-directional sliding of the carousel.
- Added `!important` to the positioning rules to prevent conflicts.