### PR TITLE
fix(runa-libro): improve flipbook loading and page turn sensitivity

### DIFF
--- a/public/runa-libro/index.html
+++ b/public/runa-libro/index.html
@@ -86,7 +86,7 @@
         html.dark .font-button.active { background-color: rgba(255,255,255,0.3); }
 
 
-        .flipbook-viewport { display: flex; justify-content: center; align-items: center; height: 100vh; width: 100vw; position: fixed; top: 0; left: 0; }
+        .flipbook-viewport { display: flex; justify-content: center; align-items: center; height: 100vh; width: 100vw; position: fixed; top: 0; left: 0; visibility: hidden; }
         .flipbook-container { width: 90vw; height: 85vh; max-width: 500px; max-height: 700px; position: relative; }
         .flipbook { width: 100%; height: 100%; }
         .flipbook .page { box-shadow: 0 4px 10px rgba(0,0,0,0.3); transition: background-color 0.3s ease, color 0.3s ease; position: relative; overflow: hidden; }
@@ -1192,8 +1192,10 @@
             height: $('.flipbook-container').height(),
             display: 'single',
             elevation: 50,
-            gradients: true,
+            gradients: false,
             autoCenter: true,
+            acceleration: false,
+            duration: 300,
             when: {
                 turning: async (event, page, view) => { // Before the turn animation starts
                     // Save the state of the page that is about to turn away
@@ -1514,6 +1516,10 @@
         updateSliderFill($('#line-width-slider')[0]);
         drawColorWheel();
         colorPreview.style.backgroundColor = currentColor;
+
+        $(window).on('load', function() {
+            $('.flipbook-viewport').css('visibility', 'visible');
+        });
     });
 </script>
 


### PR DESCRIPTION
- Hid the flipbook until all assets are loaded to prevent the initial loading glitch.
- Adjusted turn.js options to make the page turning feel lighter and more responsive.