### PR TITLE
fix(runa-libro): restore page turn effect on empty pages

### DIFF
--- a/public/runa-libro/index.html
+++ b/public/runa-libro/index.html
@@ -1192,7 +1192,7 @@
             height: $('.flipbook-container').height(),
             display: 'single',
             elevation: 50,
-            gradients: false,
+            gradients: true,
             autoCenter: true,
             acceleration: false,
             duration: 300,


### PR DESCRIPTION
- Re-enabled the `gradients` option in the turn.js configuration.
- This restores the visual page curl effect on all pages, including the blank ones, while keeping the other sensitivity improvements.