### PR TITLE
Fix: Ensure Aria assistant banner is always visible when activated

### DIFF
--- a/public/css/assistant.css
+++ b/public/css/assistant.css
@@ -1,10 +1,23 @@
 /* --- Styles for Assistant Banner --- */
 
 #assistant-banner {
+    /* Base styles */
     background-color: rgba(26, 19, 16, 0.8); /* #1a1310 with 80% opacity */
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.1);
+
+    /* Visibility & Animation */
+    transition: transform 0.4s ease-out, opacity 0.4s ease-out;
+    transform: translateY(150%); /* Start off-screen */
+    opacity: 0;
+    pointer-events: none; /* Prevent interaction when hidden */
+}
+
+#assistant-banner.is-visible {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto; /* Allow interaction when visible */
 }
 
 #mic-button.recording {
@@ -21,21 +34,5 @@
     }
     100% {
         box-shadow: 0 0 0 0 rgba(22, 163, 74, 0);
-    }
-}
-
-/* Animation for the banner sliding in from the bottom */
-.modal-enter-bottom {
-    animation: slideUp 0.4s ease-out;
-}
-
-@keyframes slideUp {
-    from {
-        transform: translateY(100%);
-        opacity: 0;
-    }
-    to {
-        transform: translateY(0);
-        opacity: 1;
     }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -382,7 +382,7 @@
     </div>
     
     <!-- Banner Flotante del Asistente Aria -->
-    <div id="assistant-banner" class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl rounded-2xl shadow-2xl p-4 flex items-center gap-4 hidden modal-enter-bottom">
+    <div id="assistant-banner" class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl rounded-2xl shadow-2xl p-4 flex items-center gap-4">
         <button id="mic-button" class="flex-shrink-0 w-16 h-16 rounded-full bg-red-600 hover:bg-red-700 transition-colors text-white flex items-center justify-center text-3xl">
         </button>
         <div class="flex-grow flex flex-col gap-2 text-sm">

--- a/public/js/assistant.js
+++ b/public/js/assistant.js
@@ -14,8 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Banner Logic ---
-    const openBanner = () => assistantBanner.classList.remove('hidden');
-    const closeBanner = () => assistantBanner.classList.add('hidden');
+    const openBanner = () => assistantBanner.classList.add('is-visible');
+    const closeBanner = () => assistantBanner.classList.remove('is-visible');
 
     // Event listener for mobile menu button
     if (openAssistantBtn) {


### PR DESCRIPTION
This commit fixes a critical regression where the assistant UI would not appear after being refactored from a modal to a banner.

The root cause was likely a conflict between Tailwind's `hidden` class (which uses `display: none`) and the CSS animations for the banner.

The fix involves:
- Removing the `hidden` class from the banner's HTML.
- Implementing a new, more robust visibility system in `assistant.css` using a custom `.is-visible` class that controls `transform` and `opacity`.
- Updating `assistant.js` to toggle the `.is-visible` class instead of the `hidden` class.

This ensures the banner's appearance is reliable and its slide-in animation works as intended.