### PR TITLE
Refactor Aria assistant banner to fix visibility issue.

### DIFF
--- a/public/css/assistant.css
+++ b/public/css/assistant.css
@@ -6,6 +6,14 @@
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.1);
+    /* The transition itself is handled by Tailwind classes on the element */
+}
+
+/* This class is toggled by JS to show/hide the banner */
+.assistant-banner--hidden {
+    opacity: 0;
+    transform: translateY(100%);
+    pointer-events: none;
 }
 
 #mic-button.recording {

--- a/public/index.html
+++ b/public/index.html
@@ -382,14 +382,14 @@
     </div>
     
     <!-- Banner Flotante del Asistente Aria -->
-    <div id="assistant-banner" class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl rounded-2xl shadow-2xl p-4 flex items-center gap-4 opacity-0 translate-y-full pointer-events-none transition-all duration-500 ease-out">
+    <div id="assistant-banner" class="assistant-banner--hidden fixed bottom-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl rounded-2xl shadow-2xl p-4 flex items-center gap-4 transition-all duration-500 ease-out">
         <button id="mic-button" class="flex-shrink-0 w-16 h-16 rounded-full bg-red-600 hover:bg-red-700 transition-colors text-white flex items-center justify-center text-3xl">
         </button>
         <div class="flex-grow flex flex-col gap-2 text-sm">
             <div id="transcription-output" class="w-full p-2 rounded-lg bg-black/20 text-white/70 min-h-[20px]">Tú dijiste...</div>
             <div id="assistant-response" class="w-full p-2 rounded-lg bg-blue-900/30 text-white min-h-[20px]">Aria: ...</div>
         </div>
-        <button id="close-assistant-modal-btn" class="flex-shrink-0 text-gray-500 hover:text-white transition-colors">
+        <button id="close-assistant-modal-btn" class="flex-shrink-0 text-gray-500 hover:text-white transition-colors" aria-label="Cerrar asistente">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
         </button>
     </div>

--- a/public/js/assistant.js
+++ b/public/js/assistant.js
@@ -13,15 +13,15 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    // --- Banner Logic (Simplified Tailwind Toggle) ---
+    // --- Banner Logic (Toggles a single CSS class) ---
     const openBanner = () => {
         if (!assistantBanner) return;
-        assistantBanner.classList.remove('opacity-0', 'translate-y-full', 'pointer-events-none');
+        assistantBanner.classList.remove('assistant-banner--hidden');
     };
 
     const closeBanner = () => {
         if (!assistantBanner) return;
-        assistantBanner.classList.add('opacity-0', 'translate-y-full', 'pointer-events-none');
+        assistantBanner.classList.add('assistant-banner--hidden');
     };
 
     // --- Event Listeners ---
@@ -39,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
             openBanner();
         });
     }
+    // Add click listener to the 'X' button to close the banner
     closeAssistantBtn.addEventListener('click', closeBanner);
 
     // --- Web Speech API Logic ---


### PR DESCRIPTION
The assistant banner was not appearing when the trigger button was clicked. This was due to a potential issue with toggling multiple Tailwind CSS classes via JavaScript.

The solution refactors the implementation to use a single, dedicated CSS class (`.assistant-banner--hidden`) to control the banner's visibility.

- Replaced Tailwind utility classes in `index.html` with the new CSS class.
- Defined the `.assistant-banner--hidden` class in `assistant.css`.
- Simplified the `openBanner` and `closeBanner` functions in `assistant.js` to toggle the new class.

This change fixes the bug and makes the code more robust and maintainable. The existing close button functionality is preserved.