### PR TITLE
fix: Correct Facebook icon sizing in auth carousel

### DIFF
--- a/public/js/header_auth_animation.js
+++ b/public/js/header_auth_animation.js
@@ -30,14 +30,11 @@ window.authAnimation = {
         this.iconImg.src = provider.icon;
         this.iconImg.alt = `Iniciar sesión con ${provider.name}`;
 
-        this.iconImg.classList.remove('w-full', 'h-full', 'object-cover', 'zoom-fb-carousel');
-        this.iconImg.classList.add('w-6', 'h-6', 'object-contain');
-
+    this.iconImg.classList.remove('w-6', 'h-6', 'object-contain', 'zoom-fb-carousel', 'w-full', 'h-full', 'object-cover');
 
         if (provider.name === 'facebook') {
             this.iconImg.classList.add('zoom-fb-carousel');
         } else {
-            // Ensure non-facebook icons are standard size
             this.iconImg.classList.add('w-6', 'h-6', 'object-contain');
         }
 


### PR DESCRIPTION
This commit fixes a bug where the Facebook icon in the login button carousel was not resizing to its intended larger dimensions.

The issue was caused by conflicting CSS classes being applied simultaneously. The `updateProviderIcon` function in `public/js/header_auth_animation.js` was adding the standard size classes (`w-6`, `h-6`) to the icon before adding the special, larger class for Facebook (`zoom-fb-carousel`), causing the browser to ignore the intended size override.

The fix updates the `updateProviderIcon` function to ensure that all sizing classes are removed before applying the correct, mutually exclusive class for the current provider icon. This ensures the Facebook icon is now correctly displayed at 80x80px during the animation.